### PR TITLE
Feature/file upload action

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ Tested for:
 
 ### RESTyard v4.1.0
 
-- New Action available `FileUploadHypermediaAction`
+- New Actions available `FileUploadHypermediaAction` and `ExternalFileUploadHypermediaAction`
   - Allows to specify a action which allows file upload
   - Configuration allows for: 
     - File size limit

--- a/README.md
+++ b/README.md
@@ -273,6 +273,29 @@ The action attributes allow to specify a media type so it can be transmitted tha
 ```
 Will be rendered to siren as `type` on the action. Default is `application/json`.
 
+### File upload actions
+
+Use the `FileUploadHypermediaAction` to specify a file upload. Pass `FileUploadConfiguration` to send information to the client about allowed behaviour.
+
+Controller example:
+
+```csharp
+// controller
+[HttpPostHypermediaAction("UploadImage", typeof(UploadCarImageOp), AcceptedMediaType = DefaultMediaTypes.MultipartFormData)]
+public async Task<IActionResult> UploadCarImage()
+{
+//...
+}
+
+// action definition
+public class UploadCarImageOp : FileUploadHypermediaAction
+{
+    public UploadCarImageOp(Func<bool> canExecute, FileUploadConfiguration fileUploadConfiguration = null) : base(canExecute, fileUploadConfiguration)
+    {
+    }
+}
+````
+
 ### Calling external APIs using Actions
 
 If it is necessary to call a external API and expose that call as an action there is `HypermediaExternalAction<TParameter>` nad `HypermediaExternalAction` to be used as base for ActionTypes.
@@ -521,6 +544,21 @@ Tested for:
 - Nullable
 
 ## Release Notes
+
+### RESTyard v4.1.0
+
+- New Action available `FileUploadHypermediaAction`
+  - Allows to specify a action which allows file upload
+  - Configuration allows for: 
+    - File size limit
+    - File type
+    - single or multiple file upload
+  - Siren will have an action containing a single field with configuration values
+
+- Actions now have a filled class which indicates the class of the action:
+  - `ParameterLessAction`
+  - `ParameterAction`
+  - `FileUploadAction`
 
 ### RESTyard v3.0.3
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Will be rendered to siren as `type` on the action. Default is `application/json`
 
 ### File upload actions
 
-Use the `FileUploadHypermediaAction` to specify a file upload. Pass `FileUploadConfiguration` to send information to the client about allowed behaviour.
+Use the `FileUploadHypermediaAction` or `ExternalFileUploadHypermediaAction` to specify a file upload. Pass `FileUploadConfiguration` to send information to the client about allowed behaviour.
 
 Controller example:
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ To properly fill the placeholder variables for such routes a `KeyProducer` is re
 #### Use attributes to indicate keys
 Use the `Key` attribute to indicate which properties of the HTO should be used to fill the route template variables.
 If there is only one variable to fill it is enough to put the attribute above the desired HTO property.
+*Note*: A `HttpGetHypermediaObject` route must exists for the resolution to be added.
 
 Example:
 The route template: `[HttpGetHypermediaObject("{key:int}", typeof(MyHypermediaObject))]`

--- a/Source/CarShack/Controllers/Cars/CarsController.cs
+++ b/Source/CarShack/Controllers/Cars/CarsController.cs
@@ -50,7 +50,7 @@ namespace CarShack.Controllers.Cars
         }
 
         [HttpPostHypermediaAction("UploadImage", typeof(UploadCarImageOp), AcceptedMediaType = DefaultMediaTypes.MultipartFormData)]
-        public async Task<IActionResult> UploadCarImage(string brand, int id)
+        public async Task<IActionResult> UploadCarImage()
         {
             // todo file size check and limit
             var request = HttpContext.Request;
@@ -71,7 +71,7 @@ namespace CarShack.Controllers.Cars
                 {
                     Title = "File upload malformed",
                     Detail = $"File upload must be form-data and with boundary",
-                    Status = StatusCodes.Status400BadRequest
+                    Status = StatusCodes.Status415UnsupportedMediaType
                 });
             }
 
@@ -82,6 +82,17 @@ namespace CarShack.Controllers.Cars
             }
 
             var payloadFile = files[0];
+            var maxFileSize = 1024*1024*4;
+            if (payloadFile.Length > maxFileSize)
+            {
+                return StatusCode(StatusCodes.Status400BadRequest, new ProblemDetails
+                {
+                    Title = "File too big",
+                    Detail = $"File must be <={maxFileSize}",
+                    Status = StatusCodes.Status400BadRequest
+                });
+                
+            }
             var originalFilename = payloadFile.FileName;
             // Don't trust any file name, file extension, and file data from the request unless you trust them completely
             // Otherwise, it is very likely to cause problems such as virus uploading, disk filling, etc

--- a/Source/CarShack/Controllers/Cars/CarsController.cs
+++ b/Source/CarShack/Controllers/Cars/CarsController.cs
@@ -1,10 +1,18 @@
-﻿using CarShack.Hypermedia;
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using CarShack.Hypermedia;
 using CarShack.Hypermedia.Cars;
 using CarShack.Util;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 using RESTyard.AspNetCore.Exceptions;
+using RESTyard.AspNetCore.Hypermedia.Actions;
 using RESTyard.AspNetCore.WebApi.AttributedRoutes;
 using RESTyard.AspNetCore.WebApi.ExtensionMethods;
+using RESTyard.MediaTypes;
 
 namespace CarShack.Controllers.Cars
 {
@@ -17,7 +25,7 @@ namespace CarShack.Controllers.Cars
         {
             this.carsRoot = carsRoot;
         }
-        
+
         [HttpGetHypermediaObject("", typeof(HypermediaCarsRootHto))]
         public ActionResult GetRootDocument()
         {
@@ -39,6 +47,79 @@ namespace CarShack.Controllers.Cars
             {
                 return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
             }
+        }
+
+        [HttpPostHypermediaAction("UploadImage", typeof(UploadCarImageOp), AcceptedMediaType = DefaultMediaTypes.MultipartFormData)]
+        public async Task<IActionResult> UploadCarImage(string brand, int id)
+        {
+            // todo file size check and limit
+            var request = HttpContext.Request;
+
+            if (HttpContext.Request.Form == null)
+            {
+                return BuildMalformedRequestError();
+            }
+
+            // validation of Content-Type
+            // 1. first, it must be a form-data request
+            // 2. a boundary should be found in the Content-Type
+            if (!request.HasFormContentType
+                || !MediaTypeHeaderValue.TryParse(request.ContentType, out var mediaTypeHeader)
+                || string.IsNullOrEmpty(mediaTypeHeader.Boundary.Value))
+            {
+                return StatusCode(StatusCodes.Status415UnsupportedMediaType, new ProblemDetails
+                {
+                    Title = "File upload malformed",
+                    Detail = $"File upload must be form-data and with boundary",
+                    Status = StatusCodes.Status400BadRequest
+                });
+            }
+
+            var files = HttpContext.Request.Form.Files;
+            if (files.Count != 1)
+            {
+                return BuildMalformedRequestError();
+            }
+
+            var payloadFile = files[0];
+            var originalFilename = payloadFile.FileName;
+            // Don't trust any file name, file extension, and file data from the request unless you trust them completely
+            // Otherwise, it is very likely to cause problems such as virus uploading, disk filling, etc
+            // In short, it is necessary to restrict and verify the upload
+            await SaveToBinDir(originalFilename, payloadFile);
+
+            return Ok();
+        }
+
+        private static async Task SaveToBinDir(string originalFilename, IFormFile payloadFile)
+        {
+            // In stub load to execution folder and replace same file. In Prod dont use user supplied filename and do not store in app folder
+            var executionPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+            var targetPath = Path.Combine(executionPath, "Uploads");
+            Directory.CreateDirectory(targetPath);
+            var saveToPath = Path.Combine(targetPath, "MyUploadedFile" + Path.GetExtension(originalFilename));
+
+            await using (var targetStream = System.IO.File.Create(saveToPath))
+            {
+                await payloadFile.CopyToAsync(targetStream);
+            }
+        }
+
+        private BadRequestObjectResult BuildMalformedRequestError()
+        {
+            return BadRequest(new ProblemDetails()
+            {
+                Title = "File upload malformed",
+                Detail = "Form must contain one key: 'Payload' with Value: <file to upload>",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+    }
+
+    public class UploadCarImageOp : FileUploadHypermediaAction
+    {
+        public UploadCarImageOp(Func<bool> canExecute, FileUploadConfiguration fileUploadConfiguration = null) : base(canExecute, fileUploadConfiguration)
+        {
         }
     }
 }

--- a/Source/CarShack/Hypermedia/Hypermedia.Server.cs
+++ b/Source/CarShack/Hypermedia/Hypermedia.Server.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
+using CarShack.Controllers.Cars;
 using CarShack.Domain.Customer;
 using Microsoft.Extensions.DependencyInjection;
 using RESTyard.AspNetCore.Exceptions;
@@ -164,12 +165,21 @@ public partial class HypermediaCustomersRootHto
 
 public partial class HypermediaCarsRootHto
 {
+    [HypermediaAction(Name = "UploadCarImage", Title = "Upload a car image.")]
+    public UploadCarImageOp UploadCarImage { get; init; }
+    
     [ActivatorUtilitiesConstructor]
     public HypermediaCarsRootHto()
         : this(
             new HypermediaObjectReference(new HypermediaCarHto("VW", 2)),
             new {Brand = "Porsche", Id = 5})
     {
+        UploadCarImage = new UploadCarImageOp(() => true, new FileUploadConfiguration
+        {
+            Accepted = new List<string> { ".jpg", "image/png", "image/*" },
+            AllowMultiple = false,
+            MaxFileSizeBytes = 1024 * 1024 * 4
+        });
     }
 }
 
@@ -190,10 +200,6 @@ public partial class HypermediaCustomerHto
             new BuyCarOp(() => true, default!));
         return hto;
     }
-
-
-
-
 }
 
 public partial class HypermediaCarHto

--- a/Source/CarShack/Hypermedia/Hypermedia.Server.cs
+++ b/Source/CarShack/Hypermedia/Hypermedia.Server.cs
@@ -176,7 +176,7 @@ public partial class HypermediaCarsRootHto
     {
         UploadCarImage = new UploadCarImageOp(() => true, new FileUploadConfiguration
         {
-            Accepted = new List<string> { ".jpg", "image/png", "image/*" },
+            Accept = new List<string> { ".jpg", "image/png", "image/*" },
             AllowMultiple = false,
             MaxFileSizeBytes = 1024 * 1024 * 4
         });

--- a/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/SirenBuilderActionsTest.cs
+++ b/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/SirenBuilderActionsTest.cs
@@ -89,7 +89,8 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter
             fileUploadAction.Should().NotBeNull();
             fileUploadAction!["type"]!.Value<string>().Should().Be("file");
             fileUploadAction!["accept"]!.Value<string>().Should().Be(string.Join(", ", fileUploadConfiguration.Accept));
-            fileUploadAction!["maxfilesizebytes"]!.Value<long>().Should().Be(fileUploadConfiguration.MaxFileSizeBytes);
+            fileUploadAction!["maxFileSizeBytes"]!.Value<long>().Should().Be(fileUploadConfiguration.MaxFileSizeBytes);
+            fileUploadAction!["allowMultiple"]!.Value<bool>().Should().Be(fileUploadConfiguration.AllowMultiple);
         }
 
         private void AssertDefaultValues(JObject action, ActionParameter expectedDefaultValues)

--- a/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/SirenBuilderActionsTest.cs
+++ b/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/SirenBuilderActionsTest.cs
@@ -88,7 +88,7 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter
             var fileUploadAction = fields[0];
             fileUploadAction.Should().NotBeNull();
             fileUploadAction!["type"]!.Value<string>().Should().Be("file");
-            fileUploadAction!["accept"]!.Value<string>().Should().Be(string.Join(", ", fileUploadConfiguration.Accept));
+            fileUploadAction!["accept"]!.Value<string>().Should().Be(string.Join(",", fileUploadConfiguration.Accept));
             fileUploadAction!["maxFileSizeBytes"]!.Value<long>().Should().Be(fileUploadConfiguration.MaxFileSizeBytes);
             fileUploadAction!["allowMultiple"]!.Value<bool>().Should().Be(fileUploadConfiguration.AllowMultiple);
         }

--- a/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/SirenBuilderActionsTest.cs
+++ b/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/SirenBuilderActionsTest.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using RESTyard.AspNetCore.Hypermedia;
 using RESTyard.AspNetCore.Hypermedia.Actions;
 using RESTyard.AspNetCore.Hypermedia.Attributes;
+using RESTyard.AspNetCore.WebApi.Formatter;
 using RESTyard.AspNetCore.WebApi.RouteResolver;
 using RESTyard.MediaTypes;
 
@@ -30,21 +33,24 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter
         [TestMethod]
         public void ActionsTest()
         {
-            var routeName = typeof(ActionsHypermediaObject).Name + "_Route";
+            var routeName = nameof(ActionsHypermediaObject) + "_Route";
             RouteRegister.AddHypermediaObjectRoute(typeof(ActionsHypermediaObject), routeName, HttpMethod.GET);
 
-            var routeNameHypermediaActionNotExecutable = typeof(HypermediaActionNotExecutable).Name + "_Route";
+            var routeNameHypermediaActionNotExecutable = nameof(HypermediaActionNotExecutable) + "_Route";
             RouteRegister.AddActionRoute(typeof(HypermediaActionNotExecutable), routeNameHypermediaActionNotExecutable, HttpMethod.POST);
 
-            var routeNameHypermediaActionNoArgument = typeof(HypermediaActionNoArgument).Name + "_Route";
+            var routeNameHypermediaActionNoArgument = nameof(HypermediaActionNoArgument) + "_Route";
             RouteRegister.AddActionRoute(typeof(HypermediaActionNoArgument), routeNameHypermediaActionNoArgument, HttpMethod.POST);
 
-            var routeNameHypermediaActionWithArgument = typeof(HypermediaActionWithArgument).Name + "_Route";
+            var routeNameHypermediaActionWithArgument = nameof(HypermediaActionWithArgument) + "_Route";
             
             RouteRegister.AddActionRoute(typeof(HypermediaActionWithArgument), routeNameHypermediaActionWithArgument, HttpMethod.POST, CustomMediaType);
 
-            var routeNameRegisteredActionParameter = typeof(RegisteredActionParameter).Name + "_Route";
+            var routeNameRegisteredActionParameter = nameof(RegisteredActionParameter) + "_Route";
             RouteRegister.AddParameterTypeRoute(typeof(RegisteredActionParameter), routeNameRegisteredActionParameter, HttpMethod.GET);
+            
+            var routeNameFileUpload = nameof(FileUploadAction) + "_Route";
+            RouteRegister.AddActionRoute(typeof(FileUploadAction), routeNameFileUpload, HttpMethod.POST, DefaultMediaTypes.MultipartFormData);
 
             var ho = new ActionsHypermediaObject();
 
@@ -56,19 +62,34 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter
             AssertHasOnlySelfLink(siren, routeName);
 
             var actionsArray = (JArray) siren["actions"];
-            Assert.AreEqual(5, actionsArray.Count);
-            AssertActionBasic((JObject)siren["actions"][0], "RenamedAction", "POST", routeNameHypermediaActionNoArgument, 4,  "A Title");
-            AssertActionBasic((JObject)siren["actions"][1], "ActionNoArgument", "POST", routeNameHypermediaActionNoArgument, 3);
+            Assert.AreEqual(6, actionsArray!.Count);
+            AssertActionBasic((JObject)siren["actions"]![0], "RenamedAction", "POST", routeNameHypermediaActionNoArgument, 5,  ActionClasses.ParameterLessActionClass, "A Title");
+            AssertActionBasic((JObject)siren["actions"][1], "ActionNoArgument", "POST", routeNameHypermediaActionNoArgument, 4,  ActionClasses.ParameterLessActionClass);
 
-            AssertActionBasic((JObject)siren["actions"][2], "ActionWithArgument", "POST", routeNameHypermediaActionWithArgument, 5);
+            AssertActionBasic((JObject)siren["actions"][2], "ActionWithArgument", "POST", routeNameHypermediaActionWithArgument, 6,  ActionClasses.ParameterActionClass);
             AssertActionArgument((JObject) siren["actions"][2], CustomMediaType,  nameof(ActionParameter), nameof(ActionParameter),hasDefaultValues:true);
             AssertDefaultValues((JObject) siren["actions"][2], ActionsHypermediaObject.ActionWithArgumentDefaultValues);
             
-            AssertActionBasic((JObject)siren["actions"][3], nameof(ExternalActionNoArgument), "POST", "ExternalAction", 3);
+            AssertActionBasic((JObject)siren["actions"][3], nameof(ExternalActionNoArgument), "POST", "ExternalAction", 4,  ActionClasses.ParameterLessActionClass);
             
-            AssertActionBasic((JObject)siren["actions"][4], nameof(ExternalActionWithArgument), "DELETE", "ExternalAction", 5);
+            AssertActionBasic((JObject)siren["actions"][4], nameof(ExternalActionWithArgument), "DELETE", "ExternalAction", 6,  ActionClasses.ParameterActionClass);
             AssertActionArgument((JObject) siren["actions"][4], CustomMediaType, nameof(ActionParameter),  nameof(ActionParameter),hasDefaultValues:true);
             AssertDefaultValues((JObject) siren["actions"][4], ActionsHypermediaObject.ExternalActionWithArgumentDefaultValues);
+            
+            AssertActionBasic((JObject)siren["actions"][5], nameof(FileUploadAction), "POST", routeNameFileUpload, 6,  ActionClasses.FileUploadActionClass);
+            AssertFileUploadAction((JObject)siren["actions"][5], ho.FileUploadAction.FileUploadConfiguration);
+        }
+
+        private void AssertFileUploadAction(JObject action, FileUploadConfiguration fileUploadConfiguration)
+        {
+            action["type"].Value<string>().Should().Be(DefaultMediaTypes.MultipartFormData);
+            var fields = action["fields"];
+            fields.Count().Should().Be(1);
+            var fileUploadAction = fields[0];
+            fileUploadAction.Should().NotBeNull();
+            fileUploadAction!["type"]!.Value<string>().Should().Be("file");
+            fileUploadAction!["accept"]!.Value<string>().Should().Be(string.Join(", ", fileUploadConfiguration.Accept));
+            fileUploadAction!["maxfilesizebytes"]!.Value<long>().Should().Be(fileUploadConfiguration.MaxFileSizeBytes);
         }
 
         private void AssertDefaultValues(JObject action, ActionParameter expectedDefaultValues)
@@ -114,11 +135,13 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter
             }
         }
 
-        private void AssertActionBasic(JObject action, string actionName, string method, string routeName, int propertyCount, string actionTitle = null)
+        private void AssertActionBasic(JObject action, string actionName, string method, string routeName, int propertyCount, string actionClass, string actionTitle = null)
         {
             Assert.AreEqual(propertyCount, action.Properties().Count());
             Assert.AreEqual(actionName, action["name"]);
             Assert.AreEqual(method, action["method"]);
+            
+            Assert.AreEqual(actionClass, action["class"].Single());
             AssertRoute(((JValue)action["href"]).Value<string>(), routeName);
 
             if (!string.IsNullOrEmpty(actionTitle))
@@ -144,6 +167,8 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter
             public ExternalActionNoArgument ExternalActionNoArgument { get; private set; }
             
             public ExternalActionWithArgument ExternalActionWithArgument { get; private set; }
+            
+            public FileUploadAction FileUploadAction { get; private set; }
 
 
             public static readonly Uri  ExternalUri = new Uri(TestUrlConfig.Scheme +"://" + TestUrlConfig.Host + "/ExternalAction");
@@ -160,6 +185,13 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter
                 ActionWithArgument = new HypermediaActionWithArgument(() => true, ActionWithArgumentDefaultValues);
                 ExternalActionNoArgument = new ExternalActionNoArgument(ExternalUri, HttpMethod.POST);
                 ExternalActionWithArgument = new ExternalActionWithArgument(ExternalUri, HttpMethod.DELETE, CustomMediaType, ExternalActionWithArgumentDefaultValues);
+                FileUploadAction = new FileUploadAction(() => true, 
+                    new FileUploadConfiguration
+                    {
+                        MaxFileSizeBytes = 14,
+                        Accept = new List<string>{".png", ".jpg"},
+                        AllowMultiple = true
+                    });
             }
         }
     }
@@ -191,6 +223,13 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter
     public class HypermediaActionWithArgument : HypermediaAction<ActionParameter>
     {
         public HypermediaActionWithArgument(Func<bool> canExecute, ActionParameter defaultValues) : base(canExecute, defaultValues)
+        {
+        }
+    }
+    
+    public class FileUploadAction : FileUploadHypermediaAction
+    {
+        public FileUploadAction(Func<bool> canExecute, FileUploadConfiguration fileUploadConfiguration = null) : base(canExecute, fileUploadConfiguration)
         {
         }
     }

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/ExternalFileUploadHypermediaAction.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/ExternalFileUploadHypermediaAction.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using RESTyard.AspNetCore.WebApi.RouteResolver;
+using RESTyard.MediaTypes;
+
+namespace RESTyard.AspNetCore.Hypermedia.Actions;
+
+/// <summary>
+/// A HypermediaAction which represents a file upload.
+/// For each concrete type a corresponding attributed route must exist.
+/// </summary>
+public abstract class ExternalFileUploadHypermediaAction : HypermediaExternalActionBase, IFileUploadConfiguration
+{
+    public FileUploadConfiguration FileUploadConfiguration { get; set; }
+    
+    protected ExternalFileUploadHypermediaAction(
+        Func<bool> canExecute,
+        Uri externalUri,
+        HttpMethod httpMethod,
+        string acceptedMediaType = DefaultMediaTypes.ApplicationJson,
+        FileUploadConfiguration fileUploadConfiguration = null) : base(canExecute, externalUri, httpMethod, acceptedMediaType)
+    {
+        FileUploadConfiguration = fileUploadConfiguration ?? new FileUploadConfiguration();
+    }
+    
+    protected ExternalFileUploadHypermediaAction(
+        Uri externalUri,
+        HttpMethod httpMethod,
+        string acceptedMediaType = DefaultMediaTypes.ApplicationJson,
+        FileUploadConfiguration fileUploadConfiguration = null) : base(() => true, externalUri, httpMethod, acceptedMediaType)
+    {
+        FileUploadConfiguration = fileUploadConfiguration ?? new FileUploadConfiguration();
+    }
+
+    public override object GetPrefilledParameter()
+    {
+        return null;
+    }
+
+    public override Type ParameterType()
+    {
+        return typeof(FileUploadConfiguration);
+    }
+}

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadConfiguration.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadConfiguration.cs
@@ -23,6 +23,7 @@ public record FileUploadConfiguration
     /// <item><description>A valid MIME type string, with no extensions. E.g.: 'text/html'</description></item>
     /// <item><description>Media wildcard. E.g.: 'image/*', 'audio/*', 'video/*'</description></item>
     /// </list>
+    /// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers
     /// Default is empty indicating no limitation.
     /// </summary>
     public List<string> Accept { get; set; } = new();

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadConfiguration.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadConfiguration.cs
@@ -25,5 +25,5 @@ public record FileUploadConfiguration
     /// </list>
     /// Default is empty indicating no limitation.
     /// </summary>
-    public List<string> Accepted { get; set; } = new();
+    public List<string> Accept { get; set; } = new();
 }

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadConfiguration.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadConfiguration.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace RESTyard.AspNetCore.Hypermedia.Actions;
+
+public record FileUploadConfiguration
+{
+    /// <summary>
+    /// Max size of a single file in bytes the server will accept
+    /// </summary>
+    public long MaxFileSizeBytes { get; set; } = -1;
+    
+    /// <summary>
+    /// Max number of files accepted for upload. Default is 1 
+    /// </summary>
+    public int MaxFileCount { get; set; } = 1;
+    
+    /// <summary>
+    /// List of extensions which the client can use to limit file selection. Must not contain '.'
+    /// Default is empty indicating no limit. 
+    /// </summary>
+    public List<string> AllowedFileExtensions { get; set; } = new();
+}

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadConfiguration.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadConfiguration.cs
@@ -5,18 +5,25 @@ namespace RESTyard.AspNetCore.Hypermedia.Actions;
 public record FileUploadConfiguration
 {
     /// <summary>
-    /// Max size of a single file in bytes the server will accept
+    /// Max size of a single file in bytes the server will accept.
+    /// -1 indicating no limit.
     /// </summary>
     public long MaxFileSizeBytes { get; set; } = -1;
     
     /// <summary>
-    /// Max number of files accepted for upload. Default is 1 
+    /// Indicates if it is allowed to send multiple files.
     /// </summary>
-    public int MaxFileCount { get; set; } = 1;
+    public bool AllowMultiple { get; set; } = false;
     
     /// <summary>
-    /// List of extensions which the client can use to limit file selection. Must not contain '.'
-    /// Default is empty indicating no limit. 
+    /// Defines the file types the file input should accept as unique file type specifiers.
+    /// Examples:
+    /// <list type="bullet">
+    /// <item><description>case-insensitive filename extension, starting with a period ("."). E.g.: '.png'</description></item>
+    /// <item><description>A valid MIME type string, with no extensions. E.g.: 'text/html'</description></item>
+    /// <item><description>Media wildcard. E.g.: 'image/*', 'audio/*', 'video/*'</description></item>
+    /// </list>
+    /// Default is empty indicating no limitation.
     /// </summary>
-    public List<string> AllowedFileExtensions { get; set; } = new();
+    public List<string> Accepted { get; set; } = new();
 }

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadHypermediaAction.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadHypermediaAction.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace RESTyard.AspNetCore.Hypermedia.Actions;
+
+/// <summary>
+/// A HypermediaAction which represents a file upload.
+/// For each concrete type a corresponding attributed route must exist.
+/// </summary>
+public abstract class FileUploadHypermediaAction : HypermediaActionBase
+{
+    public FileUploadConfiguration FileUploadConfiguration { get; set; }
+    
+    protected FileUploadHypermediaAction(Func<bool> canExecute, FileUploadConfiguration fileUploadConfiguration = null) : base(canExecute)
+    {
+        FileUploadConfiguration = fileUploadConfiguration ?? new FileUploadConfiguration();
+    }
+
+    public override object GetPrefilledParameter()
+    {
+        return null;
+    }
+
+    public override Type ParameterType()
+    {
+        return null;
+    }
+}

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadHypermediaAction.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadHypermediaAction.cs
@@ -22,6 +22,6 @@ public abstract class FileUploadHypermediaAction : HypermediaActionBase
 
     public override Type ParameterType()
     {
-        return null;
+        return typeof(FileUploadConfiguration);
     }
 }

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadHypermediaAction.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/FileUploadHypermediaAction.cs
@@ -6,11 +6,16 @@ namespace RESTyard.AspNetCore.Hypermedia.Actions;
 /// A HypermediaAction which represents a file upload.
 /// For each concrete type a corresponding attributed route must exist.
 /// </summary>
-public abstract class FileUploadHypermediaAction : HypermediaActionBase
+public abstract class FileUploadHypermediaAction : HypermediaActionBase, IFileUploadConfiguration
 {
     public FileUploadConfiguration FileUploadConfiguration { get; set; }
     
     protected FileUploadHypermediaAction(Func<bool> canExecute, FileUploadConfiguration fileUploadConfiguration = null) : base(canExecute)
+    {
+        FileUploadConfiguration = fileUploadConfiguration ?? new FileUploadConfiguration();
+    }
+    
+    protected FileUploadHypermediaAction(FileUploadConfiguration fileUploadConfiguration = null) : base(() => true)
     {
         FileUploadConfiguration = fileUploadConfiguration ?? new FileUploadConfiguration();
     }

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/HypermediaExternalAction.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/HypermediaExternalAction.cs
@@ -15,7 +15,8 @@ namespace RESTyard.AspNetCore.Hypermedia.Actions
         /// </summary>
         public TParameter PrefilledValues { protected set;  get; }
 
-        public HypermediaExternalAction(Func<bool> canExecute,
+        public HypermediaExternalAction(
+            Func<bool> canExecute,
             Uri externalUri,
             HttpMethod httpMethod,
             string acceptedMediaType = DefaultMediaTypes.ApplicationJson,
@@ -25,7 +26,8 @@ namespace RESTyard.AspNetCore.Hypermedia.Actions
             PrefilledValues = prefilledValues;
         }
 
-        public HypermediaExternalAction(Uri externalUri,
+        public HypermediaExternalAction(
+            Uri externalUri,
             HttpMethod httpMethod,
             string acceptedMediaType = DefaultMediaTypes.ApplicationJson,
             TParameter prefilledValues = null)
@@ -50,12 +52,14 @@ namespace RESTyard.AspNetCore.Hypermedia.Actions
     /// </summary>
     public abstract class HypermediaExternalAction : HypermediaExternalActionBase
     {
-        protected HypermediaExternalAction(Func<bool> canExecute,
+        protected HypermediaExternalAction(
+            Func<bool> canExecute,
             Uri externalUri,
             HttpMethod httpMethod) 
             : base(canExecute, externalUri, httpMethod) { }
 
-        protected HypermediaExternalAction(Uri externalUri,
+        protected HypermediaExternalAction(
+            Uri externalUri,
             HttpMethod httpMethod)
             : base(() => true, externalUri, httpMethod) { }
 

--- a/Source/RESTyard.AspNetCore/Hypermedia/Actions/IFileUploadConfiguration.cs
+++ b/Source/RESTyard.AspNetCore/Hypermedia/Actions/IFileUploadConfiguration.cs
@@ -1,0 +1,6 @@
+namespace RESTyard.AspNetCore.Hypermedia.Actions;
+
+public interface IFileUploadConfiguration
+{
+    FileUploadConfiguration FileUploadConfiguration { get; set; }
+}

--- a/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
+++ b/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
@@ -9,7 +9,7 @@
       $(VersionSuffix)
     </VersionSuffixLocal>
 
-    <Version>4.1.0$(VersionSuffixLocal)</Version>
+    <Version>4.1.1$(VersionSuffixLocal)</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
+++ b/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
@@ -9,7 +9,7 @@
       $(VersionSuffix)
     </VersionSuffixLocal>
 
-    <Version>4.0.0$(VersionSuffixLocal)</Version>
+    <Version>4.1.0$(VersionSuffixLocal)</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
+++ b/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
@@ -37,12 +37,12 @@
 
   <!-- package image -->
   <ItemGroup>
-    <None Include=".\Images\Ry-Icon_128x128.png" Pack="true" PackagePath="\"/>
+    <None Include=".\Images\Ry-Icon_128x128.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <!-- shared references, compilation flags and build options -->
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="NJsonSchema" Version="10.8.0" />
   </ItemGroup>
 

--- a/Source/RESTyard.AspNetCore/WebApi/Formatter/ActionClasses.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/Formatter/ActionClasses.cs
@@ -1,0 +1,10 @@
+namespace RESTyard.AspNetCore.WebApi.Formatter;
+
+public static class ActionClasses
+{
+    public const string FileUploadActionClass = "FileUploadAction";
+
+    public const string ParameterLessActionClass = "ParameterLessAction";
+
+    public const string ParameterActionClass = "ParameterAction";
+}

--- a/Source/RESTyard.AspNetCore/WebApi/Formatter/RouteNames.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/Formatter/RouteNames.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace RESTyard.AspNetCore.WebApi.Formatter
 {
     static class RouteNames

--- a/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
@@ -205,7 +205,7 @@ namespace RESTyard.AspNetCore.WebApi.Formatter
 
             if (fileUploadConfiguration.Accept.Any())
             {
-                jfield.Add(new JProperty("accept", string.Join(", ", fileUploadConfiguration.Accept)));
+                jfield.Add(new JProperty("accept", string.Join(",", fileUploadConfiguration.Accept)));
             }
 
             if (fileUploadConfiguration.MaxFileSizeBytes >= 0)

--- a/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
@@ -210,7 +210,12 @@ namespace RESTyard.AspNetCore.WebApi.Formatter
 
             if (fileUploadConfiguration.MaxFileSizeBytes >= 0)
             {
-                jfield.Add(new JProperty("maxfilesizebytes", fileUploadConfiguration.MaxFileSizeBytes));
+                jfield.Add(new JProperty("maxFileSizeBytes", fileUploadConfiguration.MaxFileSizeBytes));
+            }
+            
+            if (fileUploadConfiguration.AllowMultiple)
+            {
+                jfield.Add(new JProperty("allowMultiple", true));
             }
             
             jAction.Add("class", new JArray { ActionClasses.FileUploadActionClass });

--- a/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
@@ -191,7 +191,7 @@ namespace RESTyard.AspNetCore.WebApi.Formatter
         {
             const string InputTypeFile = "file";
             
-            if (hypermediaAction is not FileUploadHypermediaAction fileUploadAction)
+            if (hypermediaAction is not IFileUploadConfiguration fileUploadAction)
             {
                 throw new Exception($"Parameter indicates file upload action but action type does not match: {hypermediaAction.GetType()}. Can not create action description.");
             }

--- a/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
@@ -203,9 +203,9 @@ namespace RESTyard.AspNetCore.WebApi.Formatter
                 { "type", InputTypeFile }
             };
 
-            if (fileUploadConfiguration.Accepted.Any())
+            if (fileUploadConfiguration.Accept.Any())
             {
-                jfield.Add(new JProperty("accept", string.Join(", ", fileUploadConfiguration.Accepted)));
+                jfield.Add(new JProperty("accept", string.Join(", ", fileUploadConfiguration.Accept)));
             }
 
             if (fileUploadConfiguration.MaxFileSizeBytes >= 0)

--- a/Source/Shared/DefaultMediaTypes.cs
+++ b/Source/Shared/DefaultMediaTypes.cs
@@ -9,5 +9,7 @@ namespace RESTyard.MediaTypes
         public const string Siren = "application/vnd.siren+json";
 
         public const string ProblemJson = "application/problem+json";
+        
+        public const string MultipartFormData = "multipart/form-data";
     }
 }

--- a/Source/Shared/DefaultMediaTypes.cs
+++ b/Source/Shared/DefaultMediaTypes.cs
@@ -11,5 +11,7 @@ namespace RESTyard.MediaTypes
         public const string ProblemJson = "application/problem+json";
         
         public const string MultipartFormData = "multipart/form-data";
+        
+        public const string OctetStream = "application/octet-stream";
     }
 }


### PR DESCRIPTION
RESTyard v4.1.0

- New Actions available `FileUploadHypermediaAction` and `ExternalFileUploadHypermediaAction`
  - Allows to specify a action which allows file upload
  - Configuration allows for: 
    - File size limit
    - File type
    - single or multiple file upload
  - Siren will have an action containing a single field with configuration values

- Actions now have a filled class which indicates the class of the action:
  - `ParameterLessAction`
  - `ParameterAction`
  - `FileUploadAction`