### PR TITLE
Downgrade client project to netstandard2.0

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -25,6 +25,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<LangVersion>latest</LangVersion>
 
     <Deterministic>true</Deterministic>
     <!-- The condition may change depending on the build system you use -->

--- a/Source/RESTyard.Client.Extensions/NewtonsoftJson/EnableLanguageFeatures.cs
+++ b/Source/RESTyard.Client.Extensions/NewtonsoftJson/EnableLanguageFeatures.cs
@@ -1,0 +1,29 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal class IsExternalInit
+    {
+    
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        public bool ReturnValue { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    public sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        public string ParameterName { get; }
+    }
+}

--- a/Source/RESTyard.Client.Extensions/NewtonsoftJson/EnableLanguageFeatures.cs
+++ b/Source/RESTyard.Client.Extensions/NewtonsoftJson/EnableLanguageFeatures.cs
@@ -20,7 +20,7 @@ namespace System.Diagnostics.CodeAnalysis
     }
 
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
-    public sealed class NotNullIfNotNullAttribute : Attribute
+    internal sealed class NotNullIfNotNullAttribute : Attribute
     {
         public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
 

--- a/Source/RESTyard.Client.Extensions/NewtonsoftJson/NewtonsoftJson.csproj
+++ b/Source/RESTyard.Client.Extensions/NewtonsoftJson/NewtonsoftJson.csproj
@@ -10,7 +10,7 @@
 		</VersionSuffixLocal>
 
 		<Version>3.0.0$(VersionSuffixLocal)</Version>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/Source/RESTyard.Client.Extensions/NewtonsoftJson/NewtonsoftJson.csproj
+++ b/Source/RESTyard.Client.Extensions/NewtonsoftJson/NewtonsoftJson.csproj
@@ -9,7 +9,7 @@
 			$(VersionSuffix)
 		</VersionSuffixLocal>
 
-		<Version>3.0.0$(VersionSuffixLocal)</Version>
+		<Version>3.0.1$(VersionSuffixLocal)</Version>
 		<TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/RESTyard.Client.Extensions/SystemNetHttp/EnableLanguageFeatures.cs
+++ b/Source/RESTyard.Client.Extensions/SystemNetHttp/EnableLanguageFeatures.cs
@@ -1,0 +1,21 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal class IsExternalInit
+    {
+    
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        public bool ReturnValue { get; }
+    }
+}

--- a/Source/RESTyard.Client.Extensions/SystemNetHttp/HttpHypermediaResolver.cs
+++ b/Source/RESTyard.Client.Extensions/SystemNetHttp/HttpHypermediaResolver.cs
@@ -174,8 +174,6 @@ namespace RESTyard.Client.Extensions.SystemNetHttp
                 return HypermediaResult.Ok(No.Thing);
             }
 
-            var innerException = GetInnerException(responseMessage);
-
             var (hasProblemDescription, problemDescription) = await this.TryReadProblemStringAsync(responseMessage);
             if (hasProblemDescription)
             {
@@ -198,8 +196,7 @@ namespace RESTyard.Client.Extensions.SystemNetHttp
                 return HypermediaResult.Error<Unit>(HypermediaProblem.ProblemDetails(problemDetailsCopy));
             }
 
-            var message = innerException?.Message ?? string.Empty;
-            return HypermediaResult.Error<Unit>(HypermediaProblem.StatusCode((int)responseMessage.StatusCode, message));
+            return HypermediaResult.Error<Unit>(HypermediaProblem.StatusCode((int)responseMessage.StatusCode));
         }
 
         private async Task<(bool hasProblemDescription, ProblemDetails? problemDescription)> TryReadProblemStringAsync(HttpResponseMessage response)
@@ -218,20 +215,6 @@ namespace RESTyard.Client.Extensions.SystemNetHttp
             {
                 return (false, null);
             }
-        }
-
-        private static Exception? GetInnerException(HttpResponseMessage result)
-        {
-            try
-            {
-                result.EnsureSuccessStatusCode();
-            }
-            catch (Exception inner)
-            {
-                return inner;
-            }
-
-            return null;
         }
 
         protected override async Task<HypermediaResult<Stream>> ResponseAsStreamAsync(HttpResponseMessage responseMessage)

--- a/Source/RESTyard.Client.Extensions/SystemNetHttp/SystemNetHttp.csproj
+++ b/Source/RESTyard.Client.Extensions/SystemNetHttp/SystemNetHttp.csproj
@@ -9,7 +9,7 @@
       $(VersionSuffix)
     </VersionSuffixLocal>
     
-    <Version>3.0.1$(VersionSuffixLocal)</Version>
+    <Version>3.0.2$(VersionSuffixLocal)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/RESTyard.Client.Extensions/SystemNetHttp/SystemNetHttp.csproj
+++ b/Source/RESTyard.Client.Extensions/SystemNetHttp/SystemNetHttp.csproj
@@ -10,7 +10,7 @@
     </VersionSuffixLocal>
     
     <Version>3.0.0$(VersionSuffixLocal)</Version>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     

--- a/Source/RESTyard.Client.Extensions/SystemNetHttp/SystemNetHttp.csproj
+++ b/Source/RESTyard.Client.Extensions/SystemNetHttp/SystemNetHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- General settings -->
@@ -9,7 +9,7 @@
       $(VersionSuffix)
     </VersionSuffixLocal>
     
-    <Version>3.0.0$(VersionSuffixLocal)</Version>
+    <Version>3.0.1$(VersionSuffixLocal)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/RESTyard.Client.Extensions/SystemTextJson/EnableLanguageFeatures.cs
+++ b/Source/RESTyard.Client.Extensions/SystemTextJson/EnableLanguageFeatures.cs
@@ -1,0 +1,21 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal class IsExternalInit
+    {
+    
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        public bool ReturnValue { get; }
+    }
+}

--- a/Source/RESTyard.Client.Extensions/SystemTextJson/SystemTextJson.csproj
+++ b/Source/RESTyard.Client.Extensions/SystemTextJson/SystemTextJson.csproj
@@ -10,7 +10,7 @@
     </VersionSuffixLocal>
     
     <Version>3.0.0$(VersionSuffixLocal)</Version>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     

--- a/Source/RESTyard.Client.Extensions/SystemTextJson/SystemTextJson.csproj
+++ b/Source/RESTyard.Client.Extensions/SystemTextJson/SystemTextJson.csproj
@@ -9,7 +9,7 @@
       $(VersionSuffix)
     </VersionSuffixLocal>
     
-    <Version>3.0.0$(VersionSuffixLocal)</Version>
+    <Version>3.0.1$(VersionSuffixLocal)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/RESTyard.Client/Extensions/EnableLanguageFeatures.cs
+++ b/Source/RESTyard.Client/Extensions/EnableLanguageFeatures.cs
@@ -1,0 +1,21 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal class IsExternalInit
+    {
+    
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        public bool ReturnValue { get; }
+    }
+}

--- a/Source/RESTyard.Client/RESTyard.Client.csproj
+++ b/Source/RESTyard.Client/RESTyard.Client.csproj
@@ -9,7 +9,7 @@
             $(VersionSuffix)
         </VersionSuffixLocal>
 
-        <Version>3.0.0$(VersionSuffixLocal)</Version>
+        <Version>3.0.1$(VersionSuffixLocal)</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/RESTyard.Client/RESTyard.Client.csproj
+++ b/Source/RESTyard.Client/RESTyard.Client.csproj
@@ -10,7 +10,7 @@
         </VersionSuffixLocal>
 
         <Version>3.0.0$(VersionSuffixLocal)</Version>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
@@ -49,5 +49,6 @@
     <ItemGroup>
       <PackageReference Include="FunicularSwitch" Version="4.0.0" />
       <PackageReference Include="FunicularSwitch.Generators" Version="2.0.0" />
+      <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     </ItemGroup>
 </Project>

--- a/Source/RESTyard.Client/RESTyard.Client.csproj
+++ b/Source/RESTyard.Client/RESTyard.Client.csproj
@@ -9,7 +9,7 @@
             $(VersionSuffix)
         </VersionSuffixLocal>
 
-        <Version>3.0.1$(VersionSuffixLocal)</Version>
+        <Version>3.0.2$(VersionSuffixLocal)</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/RESTyard.Client/Resolver/HypermediaResult.cs
+++ b/Source/RESTyard.Client/Resolver/HypermediaResult.cs
@@ -15,14 +15,14 @@ public abstract partial class HypermediaResult
 public abstract record HypermediaProblem
 {
     public static HypermediaProblem ProblemDetails(ProblemDetails pd) => new ProblemDetails_(pd);
-    public static HypermediaProblem StatusCode(int? status, string message) => new StatusCode_(status, message);
+    public static HypermediaProblem StatusCode(int? status) => new StatusCode_(status);
     public static HypermediaProblem InvalidRequest(string message) => new InvalidRequest_(message);
     public static HypermediaProblem InvalidResponse(string message) => new InvalidResponse_(message);
     public static HypermediaProblem BadHcoDefinition(string message) => new BadHcoDefinition_(message);
     public static HypermediaProblem Exception(System.Exception exception) => new Exception_(exception);
 
     public sealed record ProblemDetails_(ProblemDetails Details) : HypermediaProblem;
-    public sealed record StatusCode_(int? Status, string Message) : HypermediaProblem;
+    public sealed record StatusCode_(int? Status) : HypermediaProblem;
     public sealed record InvalidRequest_(string Message) : HypermediaProblem;
     public sealed record InvalidResponse_(string Message) : HypermediaProblem;
     public sealed record BadHcoDefinition_(string Message) : HypermediaProblem;


### PR DESCRIPTION
feat: Downgrade client project to netstandard2.0 (because it can be with langversion=latest) which enables older projects to use the most recent version still