### PR TITLE
feat: improve generation of typescript client to not break on inheritance

### DIFF
--- a/Source/RESTyard.Client.Test/Hypermedia/Hypermedia.Client.g.ts
+++ b/Source/RESTyard.Client.Test/Hypermedia/Hypermedia.Client.g.ts
@@ -1,13 +1,15 @@
-
 export type int = number;
 export type double = number;
 export type float = number;
 export type IEnumerable<T> = T[];
 export type List<T> = T[];
+export type IList<T> = T[];
 export class HypermediaObject { }
-export class HypermediaLink<T> { }
-export class HypermediaAction<T> { }
-export class HypermediaFunction<T> { }
+export class HypermediaLink<T> {
+    constructor(public relations: string[], public url: string, public type: string) { }
+}
+export class HypermediaAction<T = undefined> { }
+export class HypermediaFunction<TResult, TParameter = undefined> { }
 export class Country {
     constructor(
         public readonly Name: string
@@ -42,9 +44,9 @@ export class BuyCarParameters {
 
 export class BuyLamborghiniParameters extends BuyCarParameters {
     constructor(
-        public readonly Brand: string,
-        public readonly CarId: int,
-        public readonly Price: Nullable<double>,
+        Brand: string,
+        CarId: int,
+        Price: Nullable<double>,
         public readonly Color: string,
         public readonly OptionalProperty: Nullable<int>
     ) { super(Brand, CarId, Price); }
@@ -52,11 +54,11 @@ export class BuyLamborghiniParameters extends BuyCarParameters {
 
 export class BuyLamborghinettaParameters extends BuyLamborghiniParameters {
     constructor(
-        public readonly Brand: string,
-        public readonly CarId: int,
-        public readonly Price: Nullable<double>,
-        public readonly Color: string,
-        public readonly OptionalProperty: Nullable<int>,
+        Brand: string,
+        CarId: int,
+        Price: Nullable<double>,
+        Color: string,
+        OptionalProperty: Nullable<int>,
         public readonly HorsePower: int
     ) { super(Brand, CarId, Price, Color, OptionalProperty); }
 }

--- a/Source/RESTyard.Client.Test/Hypermedia/include.ts
+++ b/Source/RESTyard.Client.Test/Hypermedia/include.ts
@@ -1,13 +1,15 @@
-﻿
-export type int = number;
+﻿export type int = number;
 export type double = number;
 export type float = number;
 export type IEnumerable<T> = T[];
 export type List<T> = T[];
+export type IList<T> = T[];
 export class HypermediaObject { }
-export class HypermediaLink<T> { }
-export class HypermediaAction<T> { }
-export class HypermediaFunction<T> { }
+export class HypermediaLink<T> {
+    constructor(public relations: string[], public url: string, public type: string) { }
+}
+export class HypermediaAction<T = undefined> { }
+export class HypermediaFunction<TResult, TParameter = undefined> { }
 export class Country {
     constructor(
         public readonly Name: string

--- a/Source/RESTyard.ContractFirst/RESTyard.Generator/RESTyard.Generator.csproj
+++ b/Source/RESTyard.ContractFirst/RESTyard.Generator/RESTyard.Generator.csproj
@@ -11,7 +11,7 @@
     <VersionSuffixLocal Condition="'$(IsPreRelease)'!='' AND  '$(IsPreRelease)'">
       $(VersionSuffix)
     </VersionSuffixLocal>
-    <Version>0.7$(VersionSuffixLocal)</Version>
+    <Version>0.8$(VersionSuffixLocal)</Version>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>restyard-generator</ToolCommandName>
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Scriban" Version="5.7.0" />
+    <PackageReference Include="Scriban" Version="5.9.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22114.1" />
   </ItemGroup>
 

--- a/Source/RESTyard.ContractFirst/RESTyard.Generator/Templates/client/typescript.sbn
+++ b/Source/RESTyard.ContractFirst/RESTyard.Generator/Templates/client/typescript.sbn
@@ -47,13 +47,16 @@ export function match<TIn, TOut>(nullable: Nullable<TIn>, onValue: (v: TIn) => T
             currentType = findParentParameters TransferParameters.Parameters currentType.parentType
             parentParameters = array.concat (gatherParameterArguments currentType) parentParameters
         end
-        allParameters = array.concat parentParameters parameters
 }}
 export class {{ parametersType.typeName }}
     {{- if isNotEmpty parametersType.parentType }} extends {{ parametersType.parentType }}
     {{- end }} {
     constructor(
-{{- for param in allParameters }}
+{{- for param in parentParameters }}
+        {{ param }}{{ if !for.last }},{{ end }}
+{{- end }}
+{{- if (array.size parentParameters) > 0 && (array.size parameters) > 0 }},{{ end -}}
+{{- for param in parameters }}
         public readonly {{ param }}{{ if !for.last }},{{ end }}
 {{- end }}
     ) { {{ if isNotEmpty parametersType.parentType -}}


### PR DESCRIPTION
constructors no longer define parameters as 'public readonly' when they are passed onto the parent class