### PR TITLE
feat: remove public readonly modifier in derived HCOs also. bump version

### DIFF
--- a/Source/RESTyard.Client.Test/Hypermedia/Hypermedia.Client.g.ts
+++ b/Source/RESTyard.Client.Test/Hypermedia/Hypermedia.Client.g.ts
@@ -104,11 +104,11 @@ export class HypermediaCarHco extends HypermediaObject {
 
 export class DerivedCarHco extends HypermediaCarHco {
     constructor(
-        public readonly Id: Nullable<int>,
-        public readonly Brand: Nullable<string>,
-        public readonly PriceDevelopment: Nullable<IEnumerable<float>>,
-        public readonly PopularCountries: Nullable<List<Country>>,
-        public readonly MostPopularIn: Nullable<Country>,
+        Id: Nullable<int>,
+        Brand: Nullable<string>,
+        PriceDevelopment: Nullable<IEnumerable<float>>,
+        PopularCountries: Nullable<List<Country>>,
+        MostPopularIn: Nullable<Country>,
         public readonly DerivedProperty: Nullable<string>,
         public readonly item: HypermediaCustomerHco[],
         public readonly self: HypermediaLink<DerivedCarHco>,
@@ -121,15 +121,15 @@ export class DerivedCarHco extends HypermediaCarHco {
 
 export class NextLevelDerivedCarHco extends DerivedCarHco {
     constructor(
-        public readonly Id: Nullable<int>,
-        public readonly Brand: Nullable<string>,
-        public readonly PriceDevelopment: Nullable<IEnumerable<float>>,
-        public readonly PopularCountries: Nullable<List<Country>>,
-        public readonly MostPopularIn: Nullable<Country>,
-        public readonly DerivedProperty: Nullable<string>,
-        public readonly item: HypermediaCustomerHco[],
-        public readonly DerivedLink: Nullable<HypermediaLink<HypermediaCustomerHco>>,
-        public readonly Derived: Nullable<HypermediaAction>,
+        Id: Nullable<int>,
+        Brand: Nullable<string>,
+        PriceDevelopment: Nullable<IEnumerable<float>>,
+        PopularCountries: Nullable<List<Country>>,
+        MostPopularIn: Nullable<Country>,
+        DerivedProperty: Nullable<string>,
+        item: HypermediaCustomerHco[],
+        DerivedLink: Nullable<HypermediaLink<HypermediaCustomerHco>>,
+        Derived: Nullable<HypermediaAction>,
         public readonly NextLevelDerivedProperty: Nullable<string>,
         public readonly self: HypermediaLink<NextLevelDerivedCarHco>
     ) {

--- a/Source/RESTyard.ContractFirst/RESTyard.Generator/RESTyard.Generator.csproj
+++ b/Source/RESTyard.ContractFirst/RESTyard.Generator/RESTyard.Generator.csproj
@@ -11,7 +11,7 @@
     <VersionSuffixLocal Condition="'$(IsPreRelease)'!='' AND  '$(IsPreRelease)'">
       $(VersionSuffix)
     </VersionSuffixLocal>
-    <Version>0.8$(VersionSuffixLocal)</Version>
+    <Version>0.9$(VersionSuffixLocal)</Version>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>restyard-generator</ToolCommandName>

--- a/Source/RESTyard.ContractFirst/RESTyard.Generator/Templates/client/typescript.sbn
+++ b/Source/RESTyard.ContractFirst/RESTyard.Generator/Templates/client/typescript.sbn
@@ -148,7 +148,6 @@ export class {{ parametersType.typeName }}
                 parentArgumentsForCall = array.concat (gatherArguments currentDocument includeSelfLink: false) parentArgumentsForCall
             end
         end
-        allArguments = array.concat parentArguments arguments
         
 }}
 export class {{ document.name }}Hco extends {{ if isNotEmpty document.parentDocument }}
@@ -157,9 +156,13 @@ export class {{ document.name }}Hco extends {{ if isNotEmpty document.parentDocu
         HypermediaObject
     {{- end }} {
     constructor(
-{{-     for arg in allArguments }}
-        public readonly {{ arg }}{{ if !for.last }},{{ end }}
-{{-     end }}
+{{- for param in parentArguments }}
+        {{ param }}{{ if !for.last }},{{ end }}
+{{- end }}
+{{- if (array.size parentArguments) > 0 && (array.size arguments) > 0 }},{{ end -}}
+{{- for param in arguments }}
+        public readonly {{ param }}{{ if !for.last }},{{ end }}
+{{- end }}
     ) {
         super({{- for arg in parentArgumentsForCall }}{{ arg | string.split ':' | array.first }}{{ if !for.last }}, {{ end }}{{- end }});
     }


### PR DESCRIPTION
derived properties are now also properly generated