### PR TITLE
Enable .Aggregate extension for HypermediaResult

### DIFF
--- a/Source/RESTyard.Client/RESTyard.Client.csproj
+++ b/Source/RESTyard.Client/RESTyard.Client.csproj
@@ -46,8 +46,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FunicularSwitch" Version="6.1.0" />
-      <PackageReference Include="FunicularSwitch.Generators" Version="3.3.2">
+      <PackageReference Include="FunicularSwitch" Version="6.1.1" />
+      <PackageReference Include="FunicularSwitch.Generators" Version="4.2.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/Source/RESTyard.Client/Resolver/HypermediaResult.cs
+++ b/Source/RESTyard.Client/Resolver/HypermediaResult.cs
@@ -1,7 +1,6 @@
-﻿using System.Net;
+﻿using System.Collections.Immutable;
 using FunicularSwitch.Generators;
 using RESTyard.Client.Exceptions;
-using RESTyard.Client.Hypermedia;
 
 namespace RESTyard.Client.Resolver;
 
@@ -12,19 +11,40 @@ public abstract partial class HypermediaResult
 }
 
 [UnionType(CaseOrder = CaseOrder.AsDeclared)]
-public abstract record HypermediaProblem
+public abstract partial record HypermediaProblem
 {
-    public static HypermediaProblem ProblemDetails(ProblemDetails pd) => new ProblemDetails_(pd);
-    public static HypermediaProblem StatusCode(int? status) => new StatusCode_(status);
-    public static HypermediaProblem InvalidRequest(string message) => new InvalidRequest_(message);
-    public static HypermediaProblem InvalidResponse(string message) => new InvalidResponse_(message);
-    public static HypermediaProblem BadHcoDefinition(string message) => new BadHcoDefinition_(message);
-    public static HypermediaProblem Exception(System.Exception exception) => new Exception_(exception);
-
     public sealed record ProblemDetails_(ProblemDetails Details) : HypermediaProblem;
     public sealed record StatusCode_(int? Status) : HypermediaProblem;
     public sealed record InvalidRequest_(string Message) : HypermediaProblem;
     public sealed record InvalidResponse_(string Message) : HypermediaProblem;
     public sealed record BadHcoDefinition_(string Message) : HypermediaProblem;
     public sealed record Exception_(System.Exception Exc) : HypermediaProblem;
+    public sealed record Multiple_(IImmutableList<HypermediaProblem> Problems) : HypermediaProblem;
+}
+
+public static class HypermediaResultMerge
+{
+    [MergeError]
+    public static HypermediaProblem Merge(this HypermediaProblem problem, HypermediaProblem other)
+    {
+        if (problem is HypermediaProblem.Multiple_ multiple)
+        {
+            if (other is HypermediaProblem.Multiple_ otherMultiple)
+            {
+                return HypermediaProblem.Multiple(multiple.Problems.AddRange(otherMultiple.Problems));
+            }
+            else
+            {
+                return HypermediaProblem.Multiple(multiple.Problems.Add(other));
+            }
+        }
+        else if (other is HypermediaProblem.Multiple_ otherMultiple)
+        {
+            return HypermediaProblem.Multiple(otherMultiple.Problems.Insert(0, problem));
+        }
+        else
+        {
+            return HypermediaProblem.Multiple(ImmutableList.Create(problem, other));
+        }
+    }
 }


### PR DESCRIPTION
- feat: bump to newer FunicularSwitch.Generators package and support MergeError to generate .Aggregate method on HypermediaResult
- feat: introduce HypermediaProblem.Multiple_ to merge multiple hypermedia errors