### PR TITLE
Add key producer for action route if no get route is defined for containing hto

### DIFF
--- a/Source/CarShack/Controllers/Customers/CustomerController.cs
+++ b/Source/CarShack/Controllers/Customers/CustomerController.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using CarShack.Domain.Customer;
 using CarShack.Hypermedia;
@@ -12,229 +15,265 @@ using RESTyard.AspNetCore.WebApi.AttributedRoutes;
 using RESTyard.AspNetCore.WebApi.ExtensionMethods;
 using RESTyard.AspNetCore.WebApi.RouteResolver;
 
-namespace CarShack.Controllers.Customers
+namespace CarShack.Controllers.Customers;
+
+[Route("Customers")]
+[ApiController]
+public class CustomerController : Controller
 {
-    [Route("Customers")]
-    [ApiController]
-    public class CustomerController : Controller
+    private readonly ICustomerRepository customerRepository;
+    private readonly IKeyFromUriService keyFromUriService;
+
+    public CustomerController(
+        ICustomerRepository customerRepository,
+        IKeyFromUriService keyFromUriService)
     {
-        private readonly ICustomerRepository customerRepository;
-        private readonly IKeyFromUriService keyFromUriService;
-
-        public CustomerController(
-            ICustomerRepository customerRepository,
-            IKeyFromUriService keyFromUriService)
-        {
-            this.customerRepository = customerRepository;
-            this.keyFromUriService = keyFromUriService;
-        }
-
-        #region HypermediaObjects
-        // Route to the HypermediaCustomer. References to HypermediaCustomer type will be resolved to this route.
-        // This RouteTemplate also contains a key, so a RouteKeyProducer can be provided. In this case the RouteKeyProducer
-        // could be ommited and KeyAttribute could be used on HypermediaCustomer instead.
-        [HttpGet("{key:int}"), HypermediaObjectEndpoint<HypermediaCustomerHto>(typeof(CustomerRouteKeyProducer))]
-        public async Task<ActionResult> GetEntity(int key)
-        {
-            try
-            {
-                var customer = await customerRepository.GetEntityByKeyAsync(key).ConfigureAwait(false);
-                var result = HypermediaCustomerHto.FromDomain(customer);
-                return Ok(result);
-            }
-            catch (EntityNotFoundException)
-            {
-                return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
-            }
-        }
-        #endregion
-
-        #region Actions
-        [HttpPost("MyFavoriteCustomers"), HypermediaActionEndpoint<HypermediaCustomerHto>(nameof(HypermediaCustomerHto.MarkAsFavorite))]
-        public async Task<ActionResult> MarkAsFavoriteAction([HypermediaActionParameterFromBody] MarkAsFavoriteParameters favoriteCustomer)
-        {
-            if (favoriteCustomer == null)
-            {
-                var problem = new ProblemDetails
-                {
-                    Title = $"Can not use provided object of type '{typeof(MarkAsFavoriteParameters)}'",
-                    Detail = "Json or contained links might be invalid",
-                    Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
-                    Status = (int)HttpStatusCode.UnprocessableEntity,
-                };
-                return this.UnprocessableEntity(problem);
-            }
-
-            try
-            {
-                var keyFromUri = this.keyFromUriService.GetKeyFromUri<HypermediaCustomerHto, HypermediaCustomerHto.CustomKey>(favoriteCustomer.Customer);
-                if (keyFromUri.IsError)
-                {
-                    return this.BadRequest();
-                }
-                var customer = await customerRepository.GetEntityByKeyAsync(keyFromUri.GetValueOrThrow().Key).ConfigureAwait(false);
-                var hypermediaCustomer = customer.ToHto();
-
-                // Check can execute here since we need to call business logic and not rely on previously checked value from HTO passed to caller
-                if (customer.IsFavorite)
-                {
-                    return this.CanNotExecute();
-                }
-
-                DoMarkAsFavorite(hypermediaCustomer, customer);
-                return Ok();
-            }
-            catch (EntityNotFoundException)
-            {
-                return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
-            }
-            catch (InvalidLinkException e)
-            {
-                var problem = new ProblemDetails()
-                {
-                    Title = $"Can not use provided object of type '{typeof(MarkAsFavoriteParameters)}'",
-                    Detail = e.Message,
-                    Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
-                    Status = (int)HttpStatusCode.UnprocessableEntity,
-                };
-                return this.UnprocessableEntity(problem);
-            }
-            catch (CanNotExecuteActionException)
-            {
-                return this.CanNotExecute();
-            }
-        }
-
-        [HttpPost("{key:int}/BuysCar"), HypermediaActionEndpoint<HypermediaCustomerHto>(nameof(HypermediaCustomerHto.BuyCar))]
-        public async Task<ActionResult> BuyCar(int key, BuyCarParameters parameter)
-        {
-            if (parameter == null)
-            {
-                var problem = new ProblemDetails
-                {
-                    Title = $"Can not use provided object of type '{typeof(BuyCarParameters)}'",
-                    Detail = "Json or contained links might be invalid",
-                    Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
-                    Status = (int)HttpStatusCode.UnprocessableEntity,
-                };
-                return this.UnprocessableEntity(problem);
-            }
-
-            try
-            {
-                //shortcut for get car from repository
-                var car = new HypermediaCarHto(parameter.Brand, parameter.CarId);
-                var customer = await customerRepository.GetEntityByKeyAsync(key).ConfigureAwait(false);
-                //do what has to be done
-                return this.Created(Link.ByKey(new HypermediaCarHto.Key(parameter.CarId, parameter.Brand)));
-            }
-            catch (EntityNotFoundException)
-            {
-                return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
-            }
-            catch (CanNotExecuteActionException)
-            {
-                return this.CanNotExecute();
-            }
-        }
-
-        [HttpPost("{key:int}/Moves"), HypermediaActionEndpoint<HypermediaCustomerHto>(nameof(HypermediaCustomerHto.CustomerMove))]
-        public async Task<ActionResult> CustomerMove(int key, NewAddress newAddress)
-        {
-            if (newAddress == null)
-            {
-                return this.Problem(ProblemJsonBuilder.CreateBadParameters());
-            }
-
-            try
-            {
-                var customer = await customerRepository.GetEntityByKeyAsync(key).ConfigureAwait(false);
-                var hypermediaCustomer = customer.ToHto();
-                // Can execute logic is NOT checked, but is always true
-                DoMove(hypermediaCustomer, customer, newAddress);
-                return Ok();
-            }
-            catch (EntityNotFoundException)
-            {
-                return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
-            }
-            catch (CanNotExecuteActionException)
-            {
-                return this.CanNotExecute();
-            }
-            catch (ActionParameterValidationException e)
-            {
-                var problem = new ProblemDetails()
-                {
-                    Title = $"Can not use provided object of type '{typeof(NewAddress)}'",
-                    Detail = e.Message,
-                    Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
-                    Status = (int)HttpStatusCode.UnprocessableEntity,
-                };
-                return this.UnprocessableEntity(problem);
-            }
-        }
-        
-        [HttpDelete("{key:int}"), HypermediaActionEndpoint<HypermediaCustomerHto>(nameof(HypermediaCustomerHto.CustomerRemove))]
-        public ActionResult RemoveCustomer(int key)
-        {
-            try
-            {
-                return Ok();
-            }
-            catch (EntityNotFoundException)
-            {
-                return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
-            }
-            catch (CanNotExecuteActionException)
-            {
-                return this.CanNotExecute();
-            }
-            catch (ActionParameterValidationException e)
-            {
-                var problem = new ProblemDetails()
-                {
-                    Title = $"Can not use provided object of type '{typeof(NewAddress)}'",
-                    Detail = e.Message,
-                    Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
-                    Status = (int)HttpStatusCode.UnprocessableEntity,
-                };
-                return this.UnprocessableEntity(problem);
-            }
-        }
-        
-        private static void DoMarkAsFavorite(HypermediaCustomerHto hto, Customer customer)
-        {
-            customer.IsFavorite = true;
-            hto.IsFavorite = true;
-        }
-        
-        private static void DoMove(HypermediaCustomerHto hto, Customer customer, NewAddress newAddress)
-        {
-            // semantic validation is business logic
-            if (string.IsNullOrEmpty(newAddress.Address.Street))
-                throw new ActionParameterValidationException("New customer address may not be null or empty.");
-
-            // call business logic here
-            hto.Address = newAddress.Address;
-            customer.Address = new Address(
-                Street: newAddress.Address.Street,
-                Number: newAddress.Address.Number,
-                City: newAddress.Address.City,
-                ZipCode: newAddress.Address.ZipCode);
-        }
-
-        #endregion
-
-        #region TypeRoutes
-        // Provide type information for Action parameters. Does not depend on a specific customer. Optional when using
-        // MvcOptionsExtension.AutoDeliverActionParameterSchemas
-        [HttpGet("NewAddressType"), HypermediaActionParameterInfoEndpoint<NewAddress>]
-        public ActionResult NewAddressType()
-        {
-            var schema = JsonSchemaFactory.Generate(typeof(NewAddress));
-            return Ok(schema);
-        }
-        #endregion
+        this.customerRepository = customerRepository;
+        this.keyFromUriService = keyFromUriService;
     }
+
+    #region HypermediaObjects
+
+    // Route to the HypermediaCustomer. References to HypermediaCustomer type will be resolved to this route.
+    // This RouteTemplate also contains a key, so a RouteKeyProducer can be provided. In this case the RouteKeyProducer
+    // could be ommited and KeyAttribute could be used on HypermediaCustomer instead.
+    [HttpGet("{key:int}"), HypermediaObjectEndpoint<HypermediaCustomerHto>(typeof(CustomerRouteKeyProducer))]
+    public async Task<ActionResult> GetEntity(int key)
+    {
+        try
+        {
+            var customer = await customerRepository.GetEntityByKeyAsync(key).ConfigureAwait(false);
+            var result = HypermediaCustomerHto.FromDomain(customer);
+            return Ok(result);
+        }
+        catch (EntityNotFoundException)
+        {
+            return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
+        }
+    }
+
+    #endregion
+
+    #region Actions
+
+    [HttpPost("MyFavoriteCustomers"),
+     HypermediaActionEndpoint<HypermediaCustomerHto>(nameof(HypermediaCustomerHto.MarkAsFavorite))]
+    public async Task<ActionResult> MarkAsFavoriteAction(
+        [HypermediaActionParameterFromBody] MarkAsFavoriteParameters favoriteCustomer)
+    {
+        if (favoriteCustomer == null)
+        {
+            var problem = new ProblemDetails
+            {
+                Title = $"Can not use provided object of type '{typeof(MarkAsFavoriteParameters)}'",
+                Detail = "Json or contained links might be invalid",
+                Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
+                Status = (int)HttpStatusCode.UnprocessableEntity,
+            };
+            return this.UnprocessableEntity(problem);
+        }
+
+        try
+        {
+            var keyFromUri =
+                this.keyFromUriService.GetKeyFromUri<HypermediaCustomerHto, HypermediaCustomerHto.CustomKey>(
+                    favoriteCustomer.Customer);
+            if (keyFromUri.IsError)
+            {
+                return this.BadRequest();
+            }
+
+            var customer = await customerRepository.GetEntityByKeyAsync(keyFromUri.GetValueOrThrow().Key)
+                .ConfigureAwait(false);
+            var hypermediaCustomer = customer.ToHto();
+
+            // Check can execute here since we need to call business logic and not rely on previously checked value from HTO passed to caller
+            if (customer.IsFavorite)
+            {
+                return this.CanNotExecute();
+            }
+
+            DoMarkAsFavorite(hypermediaCustomer, customer);
+            return Ok();
+        }
+        catch (EntityNotFoundException)
+        {
+            return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
+        }
+        catch (InvalidLinkException e)
+        {
+            var problem = new ProblemDetails()
+            {
+                Title = $"Can not use provided object of type '{typeof(MarkAsFavoriteParameters)}'",
+                Detail = e.Message,
+                Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
+                Status = (int)HttpStatusCode.UnprocessableEntity,
+            };
+            return this.UnprocessableEntity(problem);
+        }
+        catch (CanNotExecuteActionException)
+        {
+            return this.CanNotExecute();
+        }
+    }
+
+    [HttpPost("{key:int}/BuysCar"),
+     HypermediaActionEndpoint<HypermediaCustomerHto>(nameof(HypermediaCustomerHto.BuyCar))]
+    public async Task<ActionResult> BuyCar(int key, BuyCarParameters parameter)
+    {
+        if (parameter == null)
+        {
+            var problem = new ProblemDetails
+            {
+                Title = $"Can not use provided object of type '{typeof(BuyCarParameters)}'",
+                Detail = "Json or contained links might be invalid",
+                Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
+                Status = (int)HttpStatusCode.UnprocessableEntity,
+            };
+            return this.UnprocessableEntity(problem);
+        }
+
+        try
+        {
+            //shortcut for get car from repository
+            var car = new HypermediaCarHto(parameter.Brand, parameter.CarId);
+            var customer = await customerRepository.GetEntityByKeyAsync(key).ConfigureAwait(false);
+            //do what has to be done
+            return this.Created(Link.ByKey(new HypermediaCarHto.Key(parameter.CarId, parameter.Brand)));
+        }
+        catch (EntityNotFoundException)
+        {
+            return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
+        }
+        catch (CanNotExecuteActionException)
+        {
+            return this.CanNotExecute();
+        }
+    }
+
+    [HttpPost("{key:int}/Moves"),
+     HypermediaActionEndpoint<HypermediaCustomerHto>(nameof(HypermediaCustomerHto.CustomerMove))]
+    public async Task<ActionResult> CustomerMove(int key, NewAddress newAddress)
+    {
+        if (newAddress == null)
+        {
+            return this.Problem(ProblemJsonBuilder.CreateBadParameters());
+        }
+
+        try
+        {
+            var customer = await customerRepository.GetEntityByKeyAsync(key).ConfigureAwait(false);
+            var hypermediaCustomer = customer.ToHto();
+            // Can execute logic is NOT checked, but is always true
+            DoMove(hypermediaCustomer, customer, newAddress);
+            return Ok();
+        }
+        catch (EntityNotFoundException)
+        {
+            return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
+        }
+        catch (CanNotExecuteActionException)
+        {
+            return this.CanNotExecute();
+        }
+        catch (ActionParameterValidationException e)
+        {
+            var problem = new ProblemDetails()
+            {
+                Title = $"Can not use provided object of type '{typeof(NewAddress)}'",
+                Detail = e.Message,
+                Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
+                Status = (int)HttpStatusCode.UnprocessableEntity,
+            };
+            return this.UnprocessableEntity(problem);
+        }
+    }
+
+    [HttpDelete("{key:int}"),
+     HypermediaActionEndpoint<HypermediaCustomerHto>(nameof(HypermediaCustomerHto.CustomerRemove))]
+    public ActionResult RemoveCustomer(int key)
+    {
+        try
+        {
+            return Ok();
+        }
+        catch (EntityNotFoundException)
+        {
+            return this.Problem(ProblemJsonBuilder.CreateEntityNotFound());
+        }
+        catch (CanNotExecuteActionException)
+        {
+            return this.CanNotExecute();
+        }
+        catch (ActionParameterValidationException e)
+        {
+            var problem = new ProblemDetails()
+            {
+                Title = $"Can not use provided object of type '{typeof(NewAddress)}'",
+                Detail = e.Message,
+                Type = "WebApi.HypermediaExtensions.Hypermedia.BadActionParameter",
+                Status = (int)HttpStatusCode.UnprocessableEntity,
+            };
+            return this.UnprocessableEntity(problem);
+        }
+    }
+
+    private static void DoMarkAsFavorite(HypermediaCustomerHto hto, Customer customer)
+    {
+        customer.IsFavorite = true;
+        hto.IsFavorite = true;
+    }
+
+    private static void DoMove(HypermediaCustomerHto hto, Customer customer, NewAddress newAddress)
+    {
+        // semantic validation is business logic
+        if (string.IsNullOrEmpty(newAddress.Address.Street))
+            throw new ActionParameterValidationException("New customer address may not be null or empty.");
+
+        // call business logic here
+        hto.Address = newAddress.Address;
+        customer.Address = new Address(
+            Street: newAddress.Address.Street,
+            Number: newAddress.Address.Number,
+            City: newAddress.Address.City,
+            ZipCode: newAddress.Address.ZipCode);
+    }
+
+    #endregion
+
+
+    #region TypeRoutes
+
+    // Provide type information for Action parameters. Does not depend on a specific customer. Optional when using
+    // MvcOptionsExtension.AutoDeliverActionParameterSchemas
+    [HttpGet("NewAddressType"), HypermediaActionParameterInfoEndpoint<NewAddress>]
+    public ActionResult NewAddressType()
+    {
+        var schema = JsonSchemaFactory.Generate(typeof(NewAddress));
+        return Ok(schema);
+    }
+
+    #endregion
+}
+
+[Route("api/[controller]")]
+[ApiController]
+public class CustomerPurchaseHistoryController : ControllerBase
+{
+    private static readonly ImmutableList<CustomerPurchaseHto> FakePurchases =
+    [
+        new CustomerPurchaseHto(50_000, "DE0040005000600070", "Debit"),
+        new CustomerPurchaseHto(25_750, "AT611904300234573201", "Credit"),
+        new CustomerPurchaseHto(75_325, "FR7630006000011234567890189", "Transfer"),
+        new CustomerPurchaseHto(89_990, "CH9300762011623852957", "Debit"),
+        new CustomerPurchaseHto(33_450, "NL91ABNA0417164300", "Transfer"),
+        new CustomerPurchaseHto(15_999, "ES9121000418450200051332", "Credit")
+    ];
+
+    [HttpGet("{customerId}/purchases"), HypermediaObjectEndpoint<CustomerPurchaseHistoryHto>]
+    public Task<IActionResult> GetAsync(int customerId, [FromQuery] CustomerPurchaseHistoryQuery query) =>
+        Task.FromResult<IActionResult>(
+            Ok(new CustomerPurchaseHistoryHto(
+                customerId, FakePurchases.Where(e => query.CardType == null || e.CardType == query.CardType),
+                query)));
 }

--- a/Source/CarShack/Hypermedia/Hypermedia.Server.cs
+++ b/Source/CarShack/Hypermedia/Hypermedia.Server.cs
@@ -202,7 +202,8 @@ public partial class HypermediaCustomerHto
             new CustomerMoveOp(() => true),
             new CustomerRemoveOp(() => true),
             new MarkAsFavoriteOp(() => !customer.IsFavorite),
-            new BuyCarOp(() => true, default));
+            new BuyCarOp(() => true, default),
+            (new CustomerPurchaseHistoryQuery(), new CustomerPurchaseHistoryHto.Key(customer.Id)));
         return hto;
     }
 }

--- a/Source/CarShack/Hypermedia/Schema.xml
+++ b/Source/CarShack/Hypermedia/Schema.xml
@@ -38,6 +38,9 @@
     <Parameters typeName="MarkAsFavoriteParameters" usedForActions="true" usedForQueries="false">
       <Property name="Customer" type="Uri" mandatory="true" />
     </Parameters>
+    <Parameters typeName="CustomerPurchaseHistoryQuery" usedForQueries="true" usedForActions="false">
+      <Property name="CardType" type="string" mandatory="false"/>
+    </Parameters>
     <ExternalParameters typeName="CustomerQuery" />
   </TransferParameters>
   <Documents>
@@ -133,6 +136,27 @@
         <Link rel="OkaySite" mandatory="false" />
       </Links>
     </Document>
+    <Document name="CustomerPurchase" hasSelfLink="false">
+      <Classifications>
+        <Classification class="CustomerPurchase"/>
+      </Classifications>
+      <Properties>
+        <Property name="Amount" type="int"/>
+        <Property name="CardNumber" type="string" mandatory="true"/>
+        <Property name="CardType" type="string" mandatory="true"/>
+      </Properties>
+    </Document>
+    <Document name="CustomerPurchaseHistory" isQueryResult="true">
+      <Classifications>
+        <Classification class="CustomerPurchaseHistory"/>
+      </Classifications>
+      <Properties>
+        <Property name="CustomerId" type="int" hidden="true" isKey="true"/>
+      </Properties>
+      <Entities>
+        <Entity collectionName="Purchases" document="CustomerPurchase"/>
+      </Entities>
+    </Document>
     <Document name="HypermediaCustomer">
       <Classifications>
         <Classification class="Customer" />
@@ -152,6 +176,9 @@
                    parameterTypeName="MarkAsFavoriteParameters" />
         <Operation name="BuyCar" method="Post" title="Buy a car." parameterTypeName="BuyCarParameters" resultDocument="HypermediaCar" />
       </Operations>
+      <Links>
+        <Link rel="PurchaseHistory" mandatory="true" query="CustomerPurchaseHistoryQuery" document="CustomerPurchaseHistory"/>
+      </Links>
     </Document>
     <Document name="HypermediaCustomerQueryResult" title="Query result on Customer" isQueryResult="true">
       <Classifications>

--- a/Source/RESTyard.AspNetCore.Test/AssemblyBasedTestBase.cs
+++ b/Source/RESTyard.AspNetCore.Test/AssemblyBasedTestBase.cs
@@ -61,10 +61,12 @@ public class AssemblyBasedTestBase
         var exampleHtoUsing = includeExampleHtoNamespace ? $"using {typeof(ExampleHto).Namespace};" : "";
         return $"""
                 using System;
+                using System.Collections.Generic;
                 using Microsoft.AspNetCore.Mvc;
                 using RESTyard.AspNetCore.Hypermedia;
                 using RESTyard.AspNetCore.Hypermedia.Actions;
                 using RESTyard.AspNetCore.Hypermedia.Attributes;
+                using RESTyard.AspNetCore.Query;
                 using RESTyard.AspNetCore.WebApi.AttributedRoutes;
                 using RESTyard.AspNetCore.WebApi.RouteResolver;
                 {exampleHtoUsing}
@@ -76,11 +78,12 @@ public class AssemblyBasedTestBase
     protected static string GetExampleHtoCode() => File.ReadAllText("ExampleHto.cs");
 
     protected static Type GetType<T>(Assembly assembly)
-    {
-        return GetType(assembly, typeof(T).FullName!);
-    }
+        => GetTypeByFullName(assembly, typeof(T).FullName!);
 
-    protected static Type GetType(Assembly assembly, string fullName)
+    protected static Type GetTypeByName(Assembly assembly, string name)
+        => GetTypeByFullName(assembly, $"{TestAssemblyNamespace}.{name}");
+    
+    private static Type GetTypeByFullName(Assembly assembly, string fullName)
     {
         var result = assembly.GetType(fullName);
         result.Should().NotBeNull(because: fullName);

--- a/Source/RESTyard.AspNetCore.Test/WebApi/HypermediaApiExplorerTests.cs
+++ b/Source/RESTyard.AspNetCore.Test/WebApi/HypermediaApiExplorerTests.cs
@@ -1,7 +1,17 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Reflection;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RESTyard.AspNetCore.Hypermedia;
+using RESTyard.AspNetCore.Hypermedia.Actions;
+using RESTyard.AspNetCore.Test.WebApi.Formatter;
+using RESTyard.AspNetCore.WebApi;
 using RESTyard.AspNetCore.WebApi.AttributedRoutes;
+using RESTyard.AspNetCore.WebApi.RouteResolver;
 
 namespace RESTyard.AspNetCore.Test.WebApi;
 
@@ -187,5 +197,84 @@ public class HypermediaApiExplorerTests : AssemblyBasedTestBase
         var ep2 = endpoints.Should().ContainSingle(a => a.RelativePath!.Contains("Hmo2")).Which;
         ep2.ActionDescriptor.EndpointMetadata.OfType<IHypermediaObjectEndpointMetadata>().Should().ContainSingle().Which
             .RouteType.Should().Be(assembly.GetType($"{TestAssemblyNamespace}.{derived2name}"));
+    }
+    
+    [TestMethod]
+    public void RouteToActionWithoutGetEndpointOnHto_IsResolved()
+    {
+        var assembly = CreateAssembly([
+            CreateFile(
+                /* lang=c# */
+                $$"""
+                [Route("Test")]
+                [ApiController]
+                public class Controller : ControllerBase
+                {
+                    [HttpPost("{key}/Post"), HypermediaActionEndpoint<SomeHto>(nameof(SomeHto.DoSomething))]
+                    public IActionResult Post(int key) => this.Ok(key + 5);
+                }
+                """,
+                includeExampleHtoNamespace: false),
+            CreateFile(
+                /* lang=c# */
+                $$"""
+                [HypermediaObject(Classes = ["Some"])]
+                public class SomeHto : IHypermediaObject
+                {
+                    [Key]
+                    public int Key { get; set; }
+                    
+                    [HypermediaAction(Name = "Do something", Title = "Some title")]
+                    public SomeOp DoSomething { get; set; }
+                    
+                    public SomeHto()
+                    {
+                        this.Key = 5;
+                        this.DoSomething = new SomeOp(() => true);    
+                    }
+                    
+                    public class SomeOp(Func<bool> canExecute) : HypermediaAction(canExecute);
+                }
+                """,
+                includeExampleHtoNamespace: false),
+        ]);
+        var app = CreateWebApplication(assembly);
+        var apiExplorer = app.Services.GetRequiredService<IHypermediaApiExplorer>();
+
+        var endpoints = apiExplorer.GetHypermediaEndpoints();
+        endpoints.Should().HaveCount(1);
+
+        var postEndpoint = endpoints.Should().ContainSingle(a =>
+            a.ActionDescriptor.EndpointMetadata.OfType<IHypermediaActionEndpointMetadata>().Any()).Which;
+        postEndpoint.RelativePath.Should().Be("Test/{key}/Post");
+        var actionMetadata = postEndpoint.ActionDescriptor.EndpointMetadata.OfType<IHypermediaActionEndpointMetadata>()
+            .Should().ContainSingle().Which;
+        var htoType = GetType(assembly, $"{TestAssemblyNamespace}.SomeHto");
+        var actionType = GetType(assembly, $"{TestAssemblyNamespace}.SomeHto+SomeOp");
+        actionMetadata.RouteType.Should().Be(htoType);
+        actionMetadata.ActionType.Should().Be(actionType);
+        
+        var services = new ServiceCollection();
+        services.AddSingleton<LinkGenerator, FakeLinkGenerator>();
+        services.AddSingleton<IRouteRegister>(app.Services.GetRequiredService<IRouteRegister>());
+        services.AddSingleton<IRouteKeyFactory>(app.Services.GetRequiredService<IRouteKeyFactory>());
+        var fakeHttpContext = new DefaultHttpContext()
+        {
+            RequestServices = services.BuildServiceProvider(),
+        };
+        var factory = app.Services.GetRequiredService<IRouteResolverFactory>();
+        
+        var resolver = factory.CreateRouteResolver(fakeHttpContext, new HypermediaUrlConfig()
+        {
+            Host = new HostString("test.url", 1234),
+            Scheme = "https",
+        });
+        var hto = (Activator.CreateInstance(htoType) as IHypermediaObject)!;
+        var action = htoType
+                .GetProperty("DoSomething", BindingFlags.Public | BindingFlags.Instance)!.GetMethod!
+                .Invoke(hto, null) as HypermediaActionBase;
+        var route = resolver.ActionToRoute(hto, action!);
+        route.Should().NotBeNull();
+        route.Url.Should().Be("https://test.url:1234/GenericRouteName_HypermediaAction_AttributedRoutesRegisterTest.SomeHto+SomeOp/{ key = 5 }");
     }
 }

--- a/Source/RESTyard.AspNetCore.Test/WebApi/HypermediaApiExplorerTests.cs
+++ b/Source/RESTyard.AspNetCore.Test/WebApi/HypermediaApiExplorerTests.cs
@@ -249,8 +249,8 @@ public class HypermediaApiExplorerTests : AssemblyBasedTestBase
         postEndpoint.RelativePath.Should().Be("Test/{key}/Post");
         var actionMetadata = postEndpoint.ActionDescriptor.EndpointMetadata.OfType<IHypermediaActionEndpointMetadata>()
             .Should().ContainSingle().Which;
-        var htoType = GetType(assembly, $"{TestAssemblyNamespace}.SomeHto");
-        var actionType = GetType(assembly, $"{TestAssemblyNamespace}.SomeHto+SomeOp");
+        var htoType = GetTypeByName(assembly, "SomeHto");
+        var actionType = GetTypeByName(assembly, "SomeHto+SomeOp");
         actionMetadata.RouteType.Should().Be(htoType);
         actionMetadata.ActionType.Should().Be(actionType);
         

--- a/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
+++ b/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
@@ -9,7 +9,7 @@
       $(VersionSuffix)
     </VersionSuffixLocal>
 
-    <Version>5.2.0$(VersionSuffixLocal)</Version>
+    <Version>5.2.1$(VersionSuffixLocal)</Version>
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/Source/RESTyard.AspNetCore/WebApi/AttributedRoutes/HttpMethodHypermediaAction.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/AttributedRoutes/HttpMethodHypermediaAction.cs
@@ -66,7 +66,7 @@ namespace RESTyard.AspNetCore.WebApi.AttributedRoutes
 
         string IEndpointNameMetadata.EndpointName => this.Name!;
 
-        Type IHypermediaEndpointMetadata.RouteType => throw new NotSupportedException();
+        Type IHypermediaEndpointMetadata.RouteType => this.RouteType.DeclaringType ?? throw new NotSupportedException();
         Type IHypermediaActionEndpointMetadata.ActionType => this.RouteType;
 
         private static (string Name, Type RouteType, Type? RouteKeyProducerType) Init(Type routeType, Type? routeKeyProducerType)

--- a/Source/RESTyard.AspNetCore/WebApi/RouteResolver/AttributedRoutesRegister.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/RouteResolver/AttributedRoutesRegister.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
@@ -23,59 +24,67 @@ namespace RESTyard.AspNetCore.WebApi.RouteResolver
 
         private void RegisterApiRoutes(IHypermediaApiExplorer apiExplorer)
         {
-            foreach (var apiDescription in apiExplorer.GetHypermediaEndpoints())
+            var apiDescriptions = apiExplorer.GetHypermediaEndpoints();
+            foreach (var (apiDescription, htoEndpoint) in WithMetadata<IHypermediaObjectEndpointMetadata>(
+                         apiDescriptions))
             {
-                var htoEndpoint = apiDescription.ActionDescriptor.EndpointMetadata
-                    .OfType<IHypermediaObjectEndpointMetadata>().FirstOrDefault();
-                if (htoEndpoint is not null)
+                if (!HttpMethods.IsGet(apiDescription.HttpMethod ?? ""))
                 {
-                    if (!HttpMethods.IsGet(apiDescription.HttpMethod ?? ""))
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(apiDescription.HttpMethod),
-                            apiDescription.HttpMethod, apiDescription.HttpMethod);
-                    }
-                    this.AddHypermediaObjectRoute(htoEndpoint.RouteType, htoEndpoint.EndpointName, HttpMethods.Get);
-                    this.AddRouteKeyProducer(apiDescription, htoEndpoint);
+                    throw new ArgumentOutOfRangeException(nameof(apiDescription.HttpMethod),
+                        apiDescription.HttpMethod, apiDescription.HttpMethod);
+                }
+                this.AddHypermediaObjectRoute(htoEndpoint.RouteType, htoEndpoint.EndpointName, HttpMethods.Get);
+                this.AddRouteKeyProducer(apiDescription, htoEndpoint);
+            }
+
+            foreach (var (apiDescription, actionEndpoint) in WithMetadata<IHypermediaActionEndpointMetadata>(
+                         apiDescriptions))
+            {
+                var httpMethod = apiDescription.HttpMethod;
+                var isValid = httpMethod is not null
+                              && (HttpMethods.IsPost(httpMethod)
+                                  || HttpMethods.IsPut(httpMethod)
+                                  || HttpMethods.IsPatch(httpMethod)
+                                  || HttpMethods.IsDelete(httpMethod));
+                if (!isValid)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(apiDescription.HttpMethod),
+                        apiDescription.HttpMethod, apiDescription.HttpMethod);
+                }
+                this.AddActionRoute(actionEndpoint.ActionType, actionEndpoint.EndpointName, httpMethod!, actionEndpoint.AcceptedMediaType);
+                this.TryAddDefaultRouteKeyProducer(apiDescription, actionEndpoint.RouteType);
+            }
+
+            foreach (var (apiDescription, actionParameterInfoEndpoint) in
+                     WithMetadata<IHypermediaActionParameterInfoEndpointMetadata>(apiDescriptions))
+            {
+                if (!HttpMethods.IsGet(apiDescription.HttpMethod ?? ""))
+                {
+                    throw new HypermediaException(
+                        $"Unsupported HTTP verb {apiDescription.HttpMethod} on parameter info endpoint for type {actionParameterInfoEndpoint.RouteType}");
                 }
 
-                var actionEndpoint = apiDescription.ActionDescriptor.EndpointMetadata
-                    .OfType<IHypermediaActionEndpointMetadata>().FirstOrDefault();
-                if (actionEndpoint is not null)
-                {
-                    var httpMethod = apiDescription.HttpMethod;
-                    var isValid = httpMethod is not null
-                                  && (HttpMethods.IsPost(httpMethod)
-                                      || HttpMethods.IsPut(httpMethod)
-                                      || HttpMethods.IsPatch(httpMethod)
-                                      || HttpMethods.IsDelete(httpMethod));
-                    if (!isValid)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(apiDescription.HttpMethod),
-                            apiDescription.HttpMethod, apiDescription.HttpMethod);
-                    }
-                    this.AddActionRoute(actionEndpoint.ActionType, actionEndpoint.EndpointName, httpMethod!, actionEndpoint.AcceptedMediaType);
-                }
+                this.AddParameterTypeRoute(actionParameterInfoEndpoint.RouteType,
+                    actionParameterInfoEndpoint.EndpointName, HttpMethods.Get);
+            }
+            return;
 
-                var actionParameterInfoEndpoint = apiDescription.ActionDescriptor.EndpointMetadata
-                    .OfType<IHypermediaActionParameterInfoEndpointMetadata>().FirstOrDefault();
-                if (actionParameterInfoEndpoint is not null)
+            static IEnumerable<(ApiDescription ApiDescription, TMetadata Metadata)> WithMetadata<TMetadata>(IEnumerable<ApiDescription> items)
+            {
+                foreach (var apiDescription in items)
                 {
-                    if (!HttpMethods.IsGet(apiDescription.HttpMethod ?? ""))
+                    var metadata = apiDescription.ActionDescriptor.EndpointMetadata.OfType<TMetadata>()
+                        .FirstOrDefault();
+                    if (metadata is not null)
                     {
-                        throw new HypermediaException(
-                            $"Unsupported HTTP verb {apiDescription.HttpMethod} on parameter info endpoint for type {actionParameterInfoEndpoint.RouteType}");
+                        yield return (apiDescription, metadata);
                     }
-
-                    this.AddParameterTypeRoute(actionParameterInfoEndpoint.RouteType,
-                        actionParameterInfoEndpoint.EndpointName, HttpMethods.Get);
                 }
             }
         }
 
         private void AddRouteKeyProducer(ApiDescription apiDescription, IHypermediaObjectEndpointMetadata hmoEndpoint)
         {
-            var autoAddRouteKeyProducers = HttpMethods.IsGet(apiDescription.HttpMethod ?? "");
-          
             if (hmoEndpoint.RouteKeyProducerType != null)
             {
                 if (typeof(HypermediaQueryResult).GetTypeInfo().IsAssignableFrom(hmoEndpoint.RouteType))
@@ -88,17 +97,27 @@ namespace RESTyard.AspNetCore.WebApi.RouteResolver
                 var keyProducer = (IKeyProducer)Activator.CreateInstance(hmoEndpoint.RouteKeyProducerType)!;
                 this.AddRouteKeyProducer(hmoEndpoint.RouteType, keyProducer);
             }
-            else if (autoAddRouteKeyProducers && !typeof(HypermediaQueryResult).GetTypeInfo().IsAssignableFrom(hmoEndpoint.RouteType))
+            else
             {
-                var templateToUse = apiDescription.RelativePath ?? string.Empty;
+                TryAddDefaultRouteKeyProducer(apiDescription, hmoEndpoint.RouteType);
+            }
+        }
 
-                var template = TemplateParser.Parse(templateToUse);
-                if (template.Parameters.Count > 0)
-                {
-                    this.AddRouteKeyProducer(
-                        hmoEndpoint.RouteType,
-                        RouteKeyProducer.Create(hmoEndpoint.RouteType, template.Parameters.Select(p => p.Name).ToList()));
-                }
+        private void TryAddDefaultRouteKeyProducer(ApiDescription apiDescription, Type routeType)
+        {
+            if (this.TryGetKeyProducer(routeType, out _) || typeof(HypermediaQueryResult).GetTypeInfo().IsAssignableFrom(routeType))
+            {
+                return;
+            }
+
+            var templateToUse = apiDescription.RelativePath ?? string.Empty;
+
+            var template = TemplateParser.Parse(templateToUse);
+            if (template.Parameters.Count > 0)
+            {
+                this.AddRouteKeyProducer(
+                    routeType,
+                    RouteKeyProducer.Create(routeType, template.Parameters.Select(p => p.Name).ToList()));
             }
         }
     }

--- a/Source/RESTyard.AspNetCore/WebApi/RouteResolver/AttributedRoutesRegister.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/RouteResolver/AttributedRoutesRegister.cs
@@ -61,7 +61,7 @@ namespace RESTyard.AspNetCore.WebApi.RouteResolver
                 if (!HttpMethods.IsGet(apiDescription.HttpMethod ?? ""))
                 {
                     throw new HypermediaException(
-                        $"Unsupported HTTP verb {apiDescription.HttpMethod} on parameter info endpoint for type {actionParameterInfoEndpoint.RouteType}");
+                        $"Unsupported HTTP verb {apiDescription.HttpMethod} on parameter info endpoint for type {actionParameterInfoEndpoint.RouteType}. The expected HTTP verb is GET.");
                 }
 
                 this.AddParameterTypeRoute(actionParameterInfoEndpoint.RouteType,

--- a/Source/RESTyard.AspNetCore/WebApi/RouteResolver/AttributedRoutesRegister.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/RouteResolver/AttributedRoutesRegister.cs
@@ -105,7 +105,7 @@ namespace RESTyard.AspNetCore.WebApi.RouteResolver
 
         private void TryAddDefaultRouteKeyProducer(ApiDescription apiDescription, Type routeType)
         {
-            if (this.TryGetKeyProducer(routeType, out _) || typeof(HypermediaQueryResult).GetTypeInfo().IsAssignableFrom(routeType))
+            if (this.TryGetKeyProducer(routeType, out _))
             {
                 return;
             }

--- a/Source/RESTyard.Integration.Test/Hco/Hypermedia.Client.g.cs
+++ b/Source/RESTyard.Integration.Test/Hco/Hypermedia.Client.g.cs
@@ -21,6 +21,8 @@ public class DefaultHypermediaClientBuilder
         register.Register<DerivedCarHco>();
         register.Register<NextLevelDerivedCarHco>();
         register.Register<HypermediaCustomersRootHco>();
+        register.Register<CustomerPurchaseHco>();
+        register.Register<CustomerPurchaseHistoryHco>();
         register.Register<HypermediaCustomerHco>();
         register.Register<HypermediaCustomerQueryResultHco>();
     });
@@ -34,6 +36,7 @@ public partial record NewAddress(AddressTo Address);
 public partial record AddressTo(string Street, string Number, string City, string ZipCode);
 public partial record UploadCarImageParameters(string Text, bool Flag);
 public partial record MarkAsFavoriteParameters(Uri Customer);
+public partial record CustomerPurchaseHistoryQuery(string? CardType = default);
 [HypermediaClientObject("Entrypoint")]
 public partial class HypermediaEntrypointHco : HypermediaClientObject
 {
@@ -160,6 +163,29 @@ public partial class HypermediaCustomersRootHco : HypermediaClientObject
     public IHypermediaClientFunction<HypermediaCustomerQueryResultHco, CustomerQuery>? CreateQuery { get; set; }
 }
 
+[HypermediaClientObject("CustomerPurchase")]
+public partial class CustomerPurchaseHco : HypermediaClientObject
+{
+    public int? Amount { get; set; } = default!;
+
+    [Mandatory]
+    public string CardNumber { get; set; } = default!;
+
+    [Mandatory]
+    public string CardType { get; set; } = default!;
+}
+
+[HypermediaClientObject("CustomerPurchaseHistory")]
+public partial class CustomerPurchaseHistoryHco : HypermediaClientObject
+{
+    [Mandatory]
+    [HypermediaRelations(new[] { "self" })]
+    public MandatoryHypermediaLink<CustomerPurchaseHistoryHco> Self { get; set; } = default!;
+
+    [HypermediaRelations(new[] { "Purchases" })]
+    public List<CustomerPurchaseHco> Purchases { get; set; } = default!;
+}
+
 [HypermediaClientObject("Customer")]
 public partial class HypermediaCustomerHco : HypermediaClientObject
 {
@@ -173,6 +199,10 @@ public partial class HypermediaCustomerHco : HypermediaClientObject
     [Mandatory]
     [HypermediaRelations(new[] { "self" })]
     public MandatoryHypermediaLink<HypermediaCustomerHco> Self { get; set; } = default!;
+
+    [Mandatory]
+    [HypermediaRelations(new[] { "PurchaseHistory" })]
+    public MandatoryHypermediaLink<CustomerPurchaseHistoryHco> PurchaseHistory { get; set; } = default!;
 
     [HypermediaCommand("CustomerMove")]
     public IHypermediaClientAction<NewAddress>? CustomerMove { get; set; }


### PR DESCRIPTION
- Missing key producers for hypermedia actions of objects that do not have a `GET` route (e.g. embedded entities without self link) are added.
- Missing key producers for hypermedia objects that are query results and have a key are added.