### PR TITLE
Support types DateOnly and TimeOnly

### DIFF
--- a/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/Properties/Htos.cs
+++ b/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/Properties/Htos.cs
@@ -74,6 +74,8 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter.Properties
         public Uri AnUri { get; set; }
         
         public Type AType { get; set; }
+        public DateOnly DateOnly { get; set; }
+        public TimeOnly TimeOnly { get; set; }
     }
 
     [HypermediaObject(Classes = [nameof(HypermediaObjectWithListProperties)])]

--- a/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/Properties/SirenBuilderPropertiesTest.cs
+++ b/Source/RESTyard.AspNetCore.Test/WebApi/Formatter/Properties/SirenBuilderPropertiesTest.cs
@@ -181,6 +181,8 @@ namespace RESTyard.AspNetCore.Test.WebApi.Formatter.Properties
                 AnUri = new Uri("http://localhost/myuri"),
                 ADecimal = 12345,
                 ANullableInt = 10,
+                DateOnly = new DateOnly(2025, 09, 02),
+                TimeOnly = new TimeOnly(12, 01, 35),
                 AType = typeof(int)
             };
             var siren = SirenConverter.ConvertToJson(ho);

--- a/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/Formatter/SirenConverter.cs
@@ -520,6 +520,15 @@ namespace RESTyard.AspNetCore.WebApi.Formatter
                 return new JValue(enumAsString);
             }
 
+            if (propertyType == typeof(DateOnly))
+            {
+                return new JValue(((DateOnly)value).ToString("yyyy-MM-dd"));
+            }
+
+            if (propertyType == typeof(TimeOnly))
+            {
+                return new JValue(((TimeOnly)value).ToString("HH:mm:ss"));
+            }
 
             if (propertyTypeInfo.IsValueType)
             {


### PR DESCRIPTION
Support types DateOnly and TimeOnly, which are formatted compliant with HTML5 date and time input types respectively